### PR TITLE
Dropdown testing done

### DIFF
--- a/src/calend/ae/Model.java
+++ b/src/calend/ae/Model.java
@@ -35,6 +35,8 @@ public class Model extends Application implements Initializable {
 		monthTextField,
 		dayTextField,
 		zwamiTextField;
+	public static String
+		hidden="Gregorian";
 		
 	public static void main(String[]args) {
 		launch(args);
@@ -78,6 +80,29 @@ public class Model extends Application implements Initializable {
 		result = date.format(iso);
 		
 		resultZToG.setText(zwami + " corresponds to " + result);
+	}
+	
+	public void changeGridPanes(Event e) {
+		String
+			newValue = from.getValue();
+		switch(newValue) {
+		case "Gregorian":
+			fromZwami.setVisible(false);
+			fromGreg.setVisible(true);
+			to.getItems().remove("Gregorian");
+			to.getItems().add(hidden);
+			to.setValue(hidden);
+			hidden = "Gregorian";
+			break;
+		case "Zwami":
+			fromZwami.setVisible(true);
+			fromGreg.setVisible(false);
+			to.getItems().remove("Zwami");
+			to.getItems().add(hidden);
+			to.setValue(hidden);
+			hidden = "Zwami";
+			break;
+		}
 	}
 
 }

--- a/src/calend/ae/Model.java
+++ b/src/calend/ae/Model.java
@@ -1,22 +1,32 @@
 package calend.ae;
 
-import io.zunon.LibZwami;
-
+import java.net.URL;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.ResourceBundle;
 
+import io.zunon.LibZwami;
 import javafx.application.Application;
 import javafx.event.Event;
 import javafx.fxml.FXMLLoader;
+import javafx.fxml.Initializable;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
 
-public class Model extends Application {
+public class Model extends Application implements Initializable {
 	
+	public ChoiceBox<String>
+		from,
+		to;
+	public GridPane
+		fromGreg,
+		fromZwami;
 	public Label
 		resultGToZ,
 		resultZToG;
@@ -28,6 +38,11 @@ public class Model extends Application {
 		
 	public static void main(String[]args) {
 		launch(args);
+	}
+
+	@Override
+	public void initialize(URL location, ResourceBundle resources) {
+		fromZwami.setVisible(false);
 	}
 	
 	@Override
@@ -64,4 +79,5 @@ public class Model extends Application {
 		
 		resultZToG.setText(zwami + " corresponds to " + result);
 	}
+
 }

--- a/src/calend/ae/View.fxml
+++ b/src/calend/ae/View.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.control.ChoiceBox?>
 
 <GridPane alignment="CENTER" hgap="10" vgap="10" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml" fx:controller="calend.ae.Model">
-	<ChoiceBox value="Gregorian" fx:id="from" GridPane.columnIndex="0" GridPane.rowIndex="0">
+	<ChoiceBox onAction="#changeGridPanes" value="Gregorian" fx:id="from" GridPane.columnIndex="0" GridPane.rowIndex="0">
 		<items>
 			<FXCollections fx:factory="observableArrayList">
 				<String fx:value="Gregorian" />
@@ -28,7 +28,7 @@
 		</items>
 	</ChoiceBox>
 	
-	<GridPane GridPane.columnIndex="0" GridPane.rowIndex="1" fx:id="fromGreg" alignment="CENTER" hgap="10" vgap="10">
+	<GridPane GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="2" fx:id="fromGreg" alignment="CENTER" hgap="10" vgap="10">
 		<Label fx:id="resultGToZ" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.rowSpan="2" GridPane.columnSpan="2"></Label>
 		<Label text="Year: " GridPane.columnIndex="0" GridPane.rowIndex="1"></Label>
 		<TextField fx:id="yearTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"></TextField>
@@ -38,7 +38,7 @@
 		<TextField fx:id="dayTextField" GridPane.columnIndex="1" GridPane.rowIndex="3"></TextField>
 		<Button onAction="#onClickGToZ" text="Submit" GridPane.columnIndex="0" GridPane.rowIndex="4" GridPane.columnSpan="2"></Button>
 	</GridPane>
-	<GridPane GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.rowSpan="2" fx:id="fromZwami" alignment="CENTER" hgap="10" vgap="10">
+	<GridPane GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.columnSpan="2" fx:id="fromZwami" alignment="CENTER" hgap="10" vgap="10">
 		<Label fx:id="resultZToG" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="2"></Label>
 		<Label text="Zwami: " GridPane.columnIndex="0" GridPane.rowIndex="1"></Label>
 		<TextField fx:id="zwamiTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"></TextField>

--- a/src/calend/ae/View.fxml
+++ b/src/calend/ae/View.fxml
@@ -1,38 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.String?>
 <?import java.net.URL?>
+<?import javafx.collections.FXCollections?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.ChoiceBox?>
 
-<TabPane xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml" fx:controller="calend.ae.Model">
-	<tabs>
-		<Tab closable="false" text="To Zwami">
-			<GridPane alignment="CENTER" hgap="10" vgap="10">
-				<Label fx:id="resultGToZ" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="2"></Label>
-				<Label text="Year: " GridPane.columnIndex="0" GridPane.rowIndex="1"></Label>
-				<TextField fx:id="yearTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"></TextField>
-				<Label text="Month: " GridPane.columnIndex="0" GridPane.rowIndex="2"></Label>
-				<Label text="Day: " GridPane.columnIndex="0" GridPane.rowIndex="3"></Label>
-				<TextField fx:id="monthTextField" GridPane.columnIndex="1" GridPane.rowIndex="2"></TextField>
-				<TextField fx:id="dayTextField" GridPane.columnIndex="1" GridPane.rowIndex="3"></TextField>
-				<Button onAction="#onClickGToZ" text="Submit" GridPane.columnIndex="0" GridPane.rowIndex="4" GridPane.columnSpan="2"></Button>
-			</GridPane>
-		</Tab>
-		<Tab closable="false" text="To Gregorian">
-			<GridPane alignment="CENTER" hgap="10" vgap="10">
-				<Label fx:id="resultZToG" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="2"></Label>
-				<Label text="Zwami: " GridPane.columnIndex="0" GridPane.rowIndex="1"></Label>
-				<TextField fx:id="zwamiTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"></TextField>
-				<Button onAction="#onClickZToG" text="Submit" GridPane.columnIndex="0" GridPane.rowIndex="2" GridPane.columnSpan="2"></Button>
-			</GridPane>
-		</Tab>
-	</tabs>
+<GridPane alignment="CENTER" hgap="10" vgap="10" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml" fx:controller="calend.ae.Model">
+	<ChoiceBox value="Gregorian" fx:id="from" GridPane.columnIndex="0" GridPane.rowIndex="0">
+		<items>
+			<FXCollections fx:factory="observableArrayList">
+				<String fx:value="Gregorian" />
+				<String fx:value="Zwami" />
+			</FXCollections>
+		</items>
+	</ChoiceBox>
+	<ChoiceBox value="Zwami" fx:id="to" GridPane.columnIndex="1" GridPane.rowIndex="0">
+		<items>
+			<FXCollections fx:factory="observableArrayList">
+				<String fx:value="Zwami" />
+			</FXCollections>
+		</items>
+	</ChoiceBox>
+	
+	<GridPane GridPane.columnIndex="0" GridPane.rowIndex="1" fx:id="fromGreg" alignment="CENTER" hgap="10" vgap="10">
+		<Label fx:id="resultGToZ" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.rowSpan="2" GridPane.columnSpan="2"></Label>
+		<Label text="Year: " GridPane.columnIndex="0" GridPane.rowIndex="1"></Label>
+		<TextField fx:id="yearTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"></TextField>
+		<Label text="Month: " GridPane.columnIndex="0" GridPane.rowIndex="2"></Label>
+		<Label text="Day: " GridPane.columnIndex="0" GridPane.rowIndex="3"></Label>
+		<TextField fx:id="monthTextField" GridPane.columnIndex="1" GridPane.rowIndex="2"></TextField>
+		<TextField fx:id="dayTextField" GridPane.columnIndex="1" GridPane.rowIndex="3"></TextField>
+		<Button onAction="#onClickGToZ" text="Submit" GridPane.columnIndex="0" GridPane.rowIndex="4" GridPane.columnSpan="2"></Button>
+	</GridPane>
+	<GridPane GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.rowSpan="2" fx:id="fromZwami" alignment="CENTER" hgap="10" vgap="10">
+		<Label fx:id="resultZToG" GridPane.columnIndex="0" GridPane.rowIndex="0" GridPane.columnSpan="2"></Label>
+		<Label text="Zwami: " GridPane.columnIndex="0" GridPane.rowIndex="1"></Label>
+		<TextField fx:id="zwamiTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"></TextField>
+		<Button onAction="#onClickZToG" text="Submit" GridPane.columnIndex="0" GridPane.rowIndex="2" GridPane.columnSpan="2"></Button>
+	</GridPane>
 	
 	<stylesheets>
 		<URL value="@Style.css"/>
 	</stylesheets>
-</TabPane>
+</GridPane>


### PR DESCRIPTION
now layout is more efficient with a large number of conversions instead of adding a huge number of tabs each time a date type is added, instead, this will allow us to add only one gridPane per date format/chronology and add buttons for each other one, and hide/show the buttons with the second dropdown menu